### PR TITLE
DlSym error is not catched when trying to load EGL versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1840,9 +1840,9 @@ macro_rules! api {
 								return Ok(result)
 							}
 						},
-						Err(libloading::Error::DlSym(e)) => {
+						Err(libloading::Error::DlSym { desc }) => {
 							if Version::$id == Version::EGL1_0 {
-								return Err(e) // we require at least EGL 1.0.
+								return Err(libloading::Error::DlSym { desc }) // we require at least EGL 1.0.
 							} else {
 								return Ok(result)
 							}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1840,6 +1840,13 @@ macro_rules! api {
 								return Ok(result)
 							}
 						},
+						Err(libloading::Error::DlSym(e)) => {
+							if Version::$id == Version::EGL1_0 {
+								return Err(e) // we require at least EGL 1.0.
+							} else {
+								return Ok(result)
+							}
+						},
 						Err(e) => return Err(e)
 					}
 				)*


### PR DESCRIPTION
See #11

This is required because undefined symbols will not throw DlSymUnknown but DlSym:

```
DlSym { desc: "undefined symbol: eglCreateSync" }
```
