### PR TITLE
Make pkg-config optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ build         = "build.rs"
 [features]
 default = ["1_5"]
 static = ["pkg-config"]
+no-pkg-config = []
 dynamic = ["libloading"]
 nightly = []
 "1_5" = ["1_4"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ khronos-egl = { version = ..., features = ["static"] }
 
 This will add a dependency to the [`pkg-config`](https://crates.io/crates/pkg-config) crate,
 necessary to find the EGL library at compile time.
+
+If you wish to disable linking EGL in this crate, and provide linking in
+your crate instead, enable the `no-pkg-config` feature.
+```toml
+khronos-egl = {version = ..., features = ["static", "no-pkg-config"]}
+```
+
 Here is a simple example showing how to use this library to create an EGL context when static linking is enabled.
 
 ```rust

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,8 @@
-#[cfg(feature="static")]
+#[cfg(all(feature="static", not(feature="no-pkg-config")))]
 extern crate pkg_config;
 
-
 fn main() {
-	#[cfg(feature="static")]
+	#[cfg(all(feature="static", not(feature="no-pkg-config")))]
 	{
 		pkg_config::Config::new()
 		.atleast_version("1")


### PR DESCRIPTION
I know this pull request in it's current state is unmergeable, but I'm opening it to discuss the use of pkg-config. I think it's a good feature, but since now the Raspberry Pi driver userland has renamed the Broadcom EGL library to `brcmEGL`, this crate is unusable for that use case. Ideally, I think, enabling `static` would also enable `pkg-config`, and then it would be possible to disable `pkg-config` somehow if the user of the library wishes to add their own `pkg-config` -line in their build.rs. But I don't know how to do that.