### PR TITLE
Load libEGL.so.1 or libEGL.so inside load_required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 name: ci
 
-on: [pull_request, push]
+on: [ pull_request, push ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        channel: [stable, nightly]
+        channel: [ stable, nightly ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/cargo@v1
@@ -41,3 +41,14 @@ jobs:
         run: cargo build --features "static dynamic" --all-targets
       - name: Run load-minimal
         run: cargo run --example load-minimal --features "dynamic 1_4"
+  android_build:
+    name: Android Stable
+    runs-on: ubuntu-latest
+    env:
+      TARGET: aarch64-linux-android
+    steps:
+      - uses: actions/checkout@v2
+      - run: echo "$ANDROID_HOME/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+      - name: Prepare Rust
+        run: rustup target add ${{ env.TARGET }}
+      - run: cargo build --features "dynamic 1_4" --target ${{ env.TARGET }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unpublished]
+### Changed
+- `load_required` and `load` now trying to load `libEGL.so.1` or `libEGL.so`.
+
 ## [4.0.0]
 ### Added
 - `no-pkg-config` feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1973,14 +1973,14 @@ macro_rules! api {
 			}
 
 			#[inline(always)]
-			/// Create an EGL instance by finding and loading the `libEGL.so.1` library.
+			/// Create an EGL instance by finding and loading the `libEGL.so.1` or `libEGL.so` library.
 			///
 			/// This is equivalent to `DynamicInstance::load_from_filename("libEGL.so.1")`.
 			///
 			/// ## Safety
 			/// This is fundamentally unsafe since there are no guaranties the found library complies to the EGL API.
 			pub unsafe fn load() -> Result<DynamicInstance<EGL1_0>, libloading::Error> {
-				Self::load_from_filename("libEGL.so.1")
+				Self::load_from_filename("libEGL.so.1").or(Self::load_from_filename("libEGL.so"))
 			}
 		}
 	};
@@ -2174,10 +2174,10 @@ macro_rules! api {
 			///
 			/// See [`Library::new`](libloading::Library::new)
 			/// for more details on how the `filename` argument is used.
-			/// 
+			///
 			/// On Linux plateforms, the library is loaded with the `RTLD_NODELETE` flag.
 			/// See [#14](https://github.com/timothee-haudebourg/khronos-egl/issues/14) for more details.
-			/// 
+			///
 			/// ## Safety
 			/// This is fundamentally unsafe since there are no guaranties the input library complies to the EGL API.
 			pub unsafe fn load_required_from_filename<P: AsRef<std::ffi::OsStr>>(filename: P) -> Result<DynamicInstance<$id>, LoadError<libloading::Error>> {
@@ -2193,7 +2193,7 @@ macro_rules! api {
 			}
 
 			#[inline(always)]
-			/// Create an EGL instance by finding and loading the `libEGL.so.1` library.
+			/// Create an EGL instance by finding and loading the `libEGL.so.1` or `libEGL.so` library.
 			/// This function fails if the EGL library does not provide the minimum required version given by the type parameter.
 			///
 			/// This is equivalent to `DynamicInstance::load_required_from_filename("libEGL.so.1")`.
@@ -2201,7 +2201,7 @@ macro_rules! api {
 			/// ## Safety
 			/// This is fundamentally unsafe since there are no guaranties the found library complies to the EGL API.
 			pub unsafe fn load_required() -> Result<DynamicInstance<$id>, LoadError<libloading::Error>> {
-				Self::load_required_from_filename("libEGL.so.1")
+			    Self::load_required_from_filename("libEGL.so.1").or(Self::load_required_from_filename("libEGL.so"))
 			}
 		}
 	}


### PR DESCRIPTION
Changes introduced in https://github.com/timothee-haudebourg/khronos-egl/commit/fa02f969e64898065b807d2200d769d0128375f4 break `Android` support.