### PR TITLE
Upgrade libloading to ^0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unpublished]
+### Changed
+- Upgrade dependency `libloading`: ^0.7 -> ^0.8.
+
 ## [4.1.0]
 ### Changed
 - `load_required` and `load` now trying to load `libEGL.so.1` or `libEGL.so`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ dynamic = ["libloading"]
 
 [dependencies]
 libc = "^0.2"
-libloading = { version = "^0.7", optional = true }
+libloading = { version = "^0.8", optional = true }
 
 [build-dependencies]
 pkg-config = { version = "^0.3", optional = true }


### PR DESCRIPTION
The only breaking change [libloading 0.8](https://docs.rs/libloading/0.8.0/libloading/changelog/r0_8_0/index.html) introduces is a bump in MSRV to 1.48, but I don't think this crate advertises an MSRV so it should be ok.