### PR TITLE
Fix Windows build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2013,7 +2013,10 @@ macro_rules! api {
 				$(
 					let name = stringify!($name).as_bytes();
 					let symbol = lib.get::<unsafe extern "system" fn($($atype ),*) -> $rtype>(name)?;
+					#[cfg(unix)]
 					let ptr = (&symbol.into_raw().into_raw()) as *const *mut _ as *const unsafe extern "system" fn($($atype ),*) -> $rtype;
+					#[cfg(windows)]
+					let ptr = (&symbol.into_raw().into_raw()) as *const _ as *const unsafe extern "system" fn($($atype ),*) -> $rtype;
 					assert!(!ptr.is_null());
 					raw.$name = std::mem::MaybeUninit::new(*ptr);
 				)*


### PR DESCRIPTION
The Windows build seems to be broken:
```
error[E0606]: casting `&Option<unsafe extern "system" fn() -> isize>` as `*const *mut _` is invalid
    --> src/lib.rs:2016:16
     |
2016 |                       let ptr = (&symbol.into_raw().into_raw()) as *const *mut _ as *const unsafe extern "C" fn($($atype ),*) -> $rtype;
     |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
2210 | / api! {
2211 | |     EGL1_0 : "1_0" {
2212 | |         fn eglChooseConfig(
2213 | |             display: EGLDisplay,
...    |
2362 | |     }
2363 | | }
     | |_- in this macro invocation
```

This can be tested with `cargo build --target x86_64-pc-windows-msvc --features dynamic`.

This PR fixes this.
This is required because `Symbol::into_raw()` now returns a different type depending on the OS. I applied the same code that is used in `libloading` internally: https://github.com/nagisa/rust_libloading/blob/83b1037f21850e7da0cb9c4be17ed05da63894b2/src/os/windows/mod.rs#L371.