### PR TITLE
Fix stack corruption and crash on 32 bit windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,7 +912,7 @@ mod egl1_0 {
 		}
 
 		/// Return a GL or an EGL extension function.
-		pub fn get_proc_address(&self, procname: &str) -> Option<extern "C" fn()> {
+		pub fn get_proc_address(&self, procname: &str) -> Option<extern "system" fn()> {
 			unsafe {
 				let string = CString::new(procname).unwrap();
 
@@ -1628,7 +1628,7 @@ macro_rules! api {
 			};
 
 			$(
-				extern "C" {
+				extern "system" {
 					$(
 						#[cfg(feature=$version)]
 						pub fn $name ($($arg : $atype ),* ) -> $rtype ;
@@ -1703,7 +1703,7 @@ macro_rules! api {
 			$(
 				$(
 					#[cfg(feature=$version)]
-					$name : std::mem::MaybeUninit<unsafe extern "C" fn($($atype ),*) -> $rtype>,
+					$name : std::mem::MaybeUninit<unsafe extern "system" fn($($atype ),*) -> $rtype>,
 				)*
 			)*
 		}
@@ -2012,8 +2012,8 @@ macro_rules! api {
 
 				$(
 					let name = stringify!($name).as_bytes();
-					let symbol = lib.get::<unsafe extern "C" fn($($atype ),*) -> $rtype>(name)?;
-					let ptr = (&symbol.into_raw().into_raw()) as *const *mut _ as *const unsafe extern "C" fn($($atype ),*) -> $rtype;
+					let symbol = lib.get::<unsafe extern "system" fn($($atype ),*) -> $rtype>(name)?;
+					let ptr = (&symbol.into_raw().into_raw()) as *const *mut _ as *const unsafe extern "system" fn($($atype ),*) -> $rtype;
 					assert!(!ptr.is_null());
 					raw.$name = std::mem::MaybeUninit::new(*ptr);
 				)*
@@ -2262,7 +2262,7 @@ api! {
 		fn eglGetCurrentSurface(readdraw: Int) -> EGLSurface;
 		fn eglGetDisplay(display_id: NativeDisplayType) -> EGLDisplay;
 		fn eglGetError() -> Int;
-		fn eglGetProcAddress(procname: *const c_char) -> extern "C" fn();
+		fn eglGetProcAddress(procname: *const c_char) -> extern "system" fn();
 		fn eglInitialize(display: EGLDisplay, major: *mut Int, minor: *mut Int) -> Boolean;
 		fn eglMakeCurrent(
 			display: EGLDisplay,


### PR DESCRIPTION
khronos-egl incorrectly specifies `extern "C"` for its function pointers, when they should be stdcall for windows, see [the definition of KHRONOS_APIENTRY](https://github.com/anholt/mesa/blob/01e511233b24872b08bff862ff692dfb5b22c1f4/include/KHR/khrplatform.h#L120).

Using `extern "system"` will correctly use stdcall on 32 bit windows, but `"C"` (aka cdecl) on all other platforms, including 64 bit windows and linux.

I encountered this building a 32-bit version of the Bevy breakout example and using the ANGLE translation layer.