### PR TITLE
Add call to egl.bind_api in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ fn main() -> Result<(), egl::Error> {
 		egl::NONE
 	];
 
-	egl.bind_api(egl::OPENGL_API).unwrap();
+	egl.bind_api(egl::OPENGL_API)?;
 	egl.create_context(display, config, None, &context_attributes);
 
 	Ok(())

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ fn main() -> Result<(), egl::Error> {
 		egl::NONE
 	];
 
+	egl.bind_api(egl::OPENGL_API).unwrap();
 	egl.create_context(display, config, None, &context_attributes);
 
 	Ok(())


### PR DESCRIPTION
The sample code in the README sets the context attributes to use the OpenGL 4.0 core profile, but by default this will give a BadMatch error, because the default API is OpenGL ES, which has a maximum version of 3.2 and I believe also does not allow requesting the core profile.

Adding `egl.bind_api(egl::OPENGL_API)` before the call to `create_context` makes sure that this error does not occur.