### PR TITLE
chore: make shell*.nix files more idiomatic

### DIFF
--- a/shell-wayland.nix
+++ b/shell-wayland.nix
@@ -2,10 +2,9 @@
 
 pkgs.mkShell {
 	buildInputs = [
-		pkgs.gcc
 		pkgs.libGL
 		pkgs.pkg-config
 		pkgs.wayland
 	];
-	LD_LIBRARY_PATH="${pkgs.libGL}/lib";
+	LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.libGL ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,8 @@
 
 pkgs.mkShell {
 	buildInputs = [
-		pkgs.gcc
 		pkgs.libGL
 		pkgs.pkg-config
 	];
-	LD_LIBRARY_PATH="${pkgs.libGL}/lib";
+	LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.libGL ];
 }


### PR DESCRIPTION
* `mkShell` already brings in the system's preferred compiler, removed explicit GCC
* `lib.makeLibraryPath` is saner for anyone referencing the Nix files here