### PR TITLE
Fix panic in `get_platform_display`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1776,7 +1776,10 @@ mod egl1_5 {
 			if display != NO_DISPLAY {
 				Ok(Display::from_ptr(display))
 			} else {
-				Err(self.get_error().unwrap())
+				// NOTE: The spec says that "If platform is valid but no display matching
+				// `native_display` is available, then `EGL_NO_DISPLAY` is returned;
+				// no error condition is raised in this case.". So we "emulate" the error.
+				Err(self.get_error().unwrap_or(Error::BadDisplay))
 			}
 		}
 


### PR DESCRIPTION
This PR fixes #25, https://github.com/zed-industries/zed/issues/52944 and probably something else.

The current assumption of having an error when `eglGetPlatformDisplay` returns `EGL_NO_DISPLAY` is incorrect. And `unwrap` on it causes some panic in `wgpu` doing some magic to find a suitable backend.

The [spec](https://registry.khronos.org/EGL/sdk/docs/man) for `eglGetPlatformDisplay` says this:
>  If platform is valid but no display matching native_display is available, then EGL_NO_DISPLAY is returned; no error condition is raised in this case.

Instead of unwrap this fix just returns `Error::BadDisplay` in this case.